### PR TITLE
Renamed native to nativeImpl

### DIFF
--- a/lib/animation-frame.js
+++ b/lib/animation-frame.js
@@ -1,12 +1,12 @@
 'use strict'
 
-var native = require('./native')
+var nativeImpl = require('./native')
 var now = require('./now')
 var performance = require('./performance')
 
 // Weird native implementation doesn't work if context is defined.
-var nativeRequest = native.request
-var nativeCancel = native.cancel
+var nativeRequest = nativeImpl.request
+var nativeCancel = nativeImpl.cancel
 
 /**
  * Animation frame constructor.
@@ -82,7 +82,7 @@ AnimationFrame.prototype.request = function(callback) {
     // Therefore on #cancel we do it for both.
     ++this._tickCounter
 
-    if (native.supported && this.options.useNative && !this._isCustomFrameRate) {
+    if (nativeImpl.supported && this.options.useNative && !this._isCustomFrameRate) {
         return nativeRequest(callback)
     }
 
@@ -103,7 +103,7 @@ AnimationFrame.prototype.request = function(callback) {
             self._callbacks = {}
             for (var id in callbacks) {
                 if (callbacks[id]) {
-                    if (native.supported && self.options.useNative) {
+                    if (nativeImpl.supported && self.options.useNative) {
                         nativeRequest(callbacks[id])
                     } else {
                         callbacks[id](performance.now())
@@ -126,6 +126,6 @@ AnimationFrame.prototype.request = function(callback) {
  * @api public
  */
 AnimationFrame.prototype.cancel = function(id) {
-    if (native.supported && this.options.useNative) nativeCancel(id)
+    if (nativeImpl.supported && this.options.useNative) nativeCancel(id)
     delete this._callbacks[id]
 }


### PR DESCRIPTION
On some devices, `native` cannot be used as a variable name because it is recognized as a [reserved keyword](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Future_reserved_keywords_in_older_standards).